### PR TITLE
Refactors Required: Adds customizations for shadow. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
+/.idea/misc.xml 
 .DS_Store
 /build
 /captures

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -54,7 +54,7 @@ fun FsIconWithShadow(
                     y = shadowMatrix.shadowOffsetHeight.y,
                 )
                 .blur(radius = shadowMatrix.shadowBlur)
-                .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
+                .padding(maxOf(shadowMatrix.shadowOffsetHeight.x, shadowMatrix.shadowOffsetHeight.y))
                 .size(size)
         )
         Icon(
@@ -62,7 +62,7 @@ fun FsIconWithShadow(
             contentDescription = imageResourceContentDescription,
             tint = getForegroundItemColor(),
             modifier = Modifier
-                .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
+                .padding(maxOf(shadowMatrix.shadowOffsetHeight.x, shadowMatrix.shadowOffsetHeight.y))
                 .size(size)
         )
     }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -19,7 +19,6 @@ import com.daniellegolinsky.funshinetheme.R
 import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowOffset
 import com.daniellegolinsky.funshinetheme.designelements.getForegroundItemColor
 import com.daniellegolinsky.funshinetheme.designelements.getShadowAlpha
-import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowBlurRadius
 import com.daniellegolinsky.funshinetheme.designelements.getShadowBlurRadius
 import com.daniellegolinsky.funshinetheme.designelements.getShadowXOffset
 import com.daniellegolinsky.funshinetheme.designelements.getShadowYOffset
@@ -35,11 +34,12 @@ fun FsIconWithShadow(
     image: Painter,
     imageResourceContentDescription: String?,
     size: Dp,
-    providedShadowHeight: DpOffset? = null,
+    providedShadowDepth: DpOffset? = null,
+    providedBlur: Dp? = null,
     modifier: Modifier = Modifier
 ) {
-    val shadowOffset = providedShadowHeight ?: getDefaultShadowOffset()
-    val shadowBlur = getShadowBlurRadius(size)
+    val shadowOffset = providedShadowDepth ?: getDefaultShadowOffset()
+    val shadowBlur = providedBlur ?: getShadowBlurRadius(size)
 
     Box(
         modifier = modifier

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -1,6 +1,7 @@
 package com.daniellegolinsky.funshinetheme.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -31,24 +32,24 @@ fun FsIconWithShadow(
     imageResourceContentDescription: String?,
     modifier: Modifier = Modifier
 ) {
-    Box(modifier = modifier.fillMaxWidth()) {
+    Box() {
         Icon(
             painter = image,
             contentDescription = null,
-            modifier = Modifier
+            modifier = modifier
                 .alpha(alpha = getShadowAlpha())
                 .offset(
                     x = getShadowXOffset(),
                     y = getShadowYOffset()
                 ) // TODO This will be an angle and customizable
                 .blur(radius = getShadowBlurRadius())
-                .padding(maxOf(getShadowXOffset(), getShadowYOffset())),
+                .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
         )
         Icon(
             painter = image,
             contentDescription = imageResourceContentDescription,
             tint = getForegroundItemColor(),
-            modifier = Modifier.padding(maxOf(getShadowXOffset(), getShadowYOffset())),
+            modifier = modifier.padding(maxOf(getShadowXOffset(), getShadowYOffset())),
         )
     }
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.R
+import com.daniellegolinsky.funshinetheme.designelements.Shadow
+import com.daniellegolinsky.funshinetheme.designelements.ShadowMatrix
 import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowOffset
 import com.daniellegolinsky.funshinetheme.designelements.getForegroundItemColor
 import com.daniellegolinsky.funshinetheme.designelements.getShadowAlpha
@@ -34,12 +36,10 @@ fun FsIconWithShadow(
     image: Painter,
     imageResourceContentDescription: String?,
     size: Dp,
-    providedShadowDepth: DpOffset? = null,
-    providedBlur: Dp? = null,
+    providedShadowMatrix: ShadowMatrix? = null,
     modifier: Modifier = Modifier
 ) {
-    val shadowOffset = providedShadowDepth ?: getDefaultShadowOffset()
-    val shadowBlur = providedBlur ?: getShadowBlurRadius(size)
+    val shadowMatrix = providedShadowMatrix ?: Shadow.getDefaultInformationShadow()
 
     Box(
         modifier = modifier
@@ -50,10 +50,10 @@ fun FsIconWithShadow(
             modifier = Modifier
                 .alpha(alpha = getShadowAlpha())
                 .offset(
-                    x = shadowOffset.x,
-                    y = shadowOffset.y,
+                    x = shadowMatrix.shadowOffsetHeight.x,
+                    y = shadowMatrix.shadowOffsetHeight.y,
                 )
-                .blur(radius = shadowBlur)
+                .blur(radius = shadowMatrix.shadowBlur)
                 .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
                 .size(size)
         )

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -3,8 +3,10 @@ package com.daniellegolinsky.funshinetheme.components
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,6 +15,8 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.R
 import com.daniellegolinsky.funshinetheme.designelements.getForegroundItemColor
 import com.daniellegolinsky.funshinetheme.designelements.getShadowAlpha
@@ -32,11 +36,13 @@ fun FsIconWithShadow(
     imageResourceContentDescription: String?,
     modifier: Modifier = Modifier
 ) {
-    Box() {
+    Box(
+        modifier = modifier
+    ) {
         Icon(
             painter = image,
             contentDescription = null,
-            modifier = modifier
+            modifier = Modifier
                 .alpha(alpha = getShadowAlpha())
                 .offset(
                     x = getShadowXOffset(),
@@ -44,12 +50,13 @@ fun FsIconWithShadow(
                 ) // TODO This will be an angle and customizable
                 .blur(radius = getShadowBlurRadius())
                 .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
+//                .fillMaxWidth()
         )
         Icon(
             painter = image,
             contentDescription = imageResourceContentDescription,
             tint = getForegroundItemColor(),
-            modifier = modifier.padding(maxOf(getShadowXOffset(), getShadowYOffset())),
+            modifier = Modifier.padding(maxOf(getShadowXOffset(), getShadowYOffset())),
         )
     }
 }
@@ -60,5 +67,15 @@ fun PreviewWeatherStatusImage() {
     FsIconWithShadow(
         image = painterResource(id = R.drawable.ic_circle_black),
         imageResourceContentDescription = "Circle"
+    )
+}
+
+@Preview
+@Composable
+fun PreviewWeatherStatusImageWH() {
+    FsIconWithShadow(
+        image = painterResource(id = R.drawable.ic_circle_black),
+        imageResourceContentDescription = "Circle",
+        modifier = Modifier.width(128.dp).height(128.dp)
     )
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -19,6 +19,7 @@ import com.daniellegolinsky.funshinetheme.R
 import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowOffset
 import com.daniellegolinsky.funshinetheme.designelements.getForegroundItemColor
 import com.daniellegolinsky.funshinetheme.designelements.getShadowAlpha
+import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowBlurRadius
 import com.daniellegolinsky.funshinetheme.designelements.getShadowBlurRadius
 import com.daniellegolinsky.funshinetheme.designelements.getShadowXOffset
 import com.daniellegolinsky.funshinetheme.designelements.getShadowYOffset
@@ -34,9 +35,12 @@ fun FsIconWithShadow(
     image: Painter,
     imageResourceContentDescription: String?,
     size: Dp,
-    shadowOffset: DpOffset = getDefaultShadowOffset(), // TODO Make this conditional on size?
+    providedShadowHeight: DpOffset? = null,
     modifier: Modifier = Modifier
 ) {
+    val shadowOffset = providedShadowHeight ?: getDefaultShadowOffset()
+    val shadowBlur = getShadowBlurRadius(size)
+
     Box(
         modifier = modifier
     ) {
@@ -49,7 +53,7 @@ fun FsIconWithShadow(
                     x = shadowOffset.x,
                     y = shadowOffset.y,
                 )
-                .blur(radius = getShadowBlurRadius())
+                .blur(radius = shadowBlur)
                 .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
                 .size(size)
         )

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/components/FsIconWithShadow.kt
@@ -1,12 +1,9 @@
 package com.daniellegolinsky.funshinetheme.components
 
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -16,8 +13,10 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.R
+import com.daniellegolinsky.funshinetheme.designelements.getDefaultShadowOffset
 import com.daniellegolinsky.funshinetheme.designelements.getForegroundItemColor
 import com.daniellegolinsky.funshinetheme.designelements.getShadowAlpha
 import com.daniellegolinsky.funshinetheme.designelements.getShadowBlurRadius
@@ -34,6 +33,8 @@ import com.daniellegolinsky.funshinetheme.designelements.getShadowYOffset
 fun FsIconWithShadow(
     image: Painter,
     imageResourceContentDescription: String?,
+    size: Dp,
+    shadowOffset: DpOffset = getDefaultShadowOffset(), // TODO Make this conditional on size?
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -45,18 +46,20 @@ fun FsIconWithShadow(
             modifier = Modifier
                 .alpha(alpha = getShadowAlpha())
                 .offset(
-                    x = getShadowXOffset(),
-                    y = getShadowYOffset()
-                ) // TODO This will be an angle and customizable
+                    x = shadowOffset.x,
+                    y = shadowOffset.y,
+                )
                 .blur(radius = getShadowBlurRadius())
                 .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
-//                .fillMaxWidth()
+                .size(size)
         )
         Icon(
             painter = image,
             contentDescription = imageResourceContentDescription,
             tint = getForegroundItemColor(),
-            modifier = Modifier.padding(maxOf(getShadowXOffset(), getShadowYOffset())),
+            modifier = Modifier
+                .padding(maxOf(getShadowXOffset(), getShadowYOffset()))
+                .size(size)
         )
     }
 }
@@ -66,16 +69,17 @@ fun FsIconWithShadow(
 fun PreviewWeatherStatusImage() {
     FsIconWithShadow(
         image = painterResource(id = R.drawable.ic_circle_black),
-        imageResourceContentDescription = "Circle"
+        imageResourceContentDescription = "Circle",
+        size = 128.dp,
     )
 }
 
 @Preview
 @Composable
-fun PreviewWeatherStatusImageWH() {
+fun PreviewWeatherStatusImageSmaller() {
     FsIconWithShadow(
         image = painterResource(id = R.drawable.ic_circle_black),
         imageResourceContentDescription = "Circle",
-        modifier = Modifier.width(128.dp).height(128.dp)
+        size = 64.dp,
     )
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
@@ -4,26 +4,40 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS
-import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_FLOAT
-import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_Y_FLOAT
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS_HALF
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_Y
 
 object ThemeConstants {
-    const val SHADOW_OFFSET_X_FLOAT = 40.0f
-    const val SHADOW_OFFSET_Y_FLOAT = 40.0f
+    const val SHADOW_OFFSET_X = 40.0f
+    const val SHADOW_OFFSET_Y = 40.0f
+    const val SHADOW_OFFSET_X_HALF = 20.0f
+    const val SHADOW_OFFSET_Y_HALF = 20.0f
+    const val SHADOW_OFFSET_X_QUARTER = 10.0f
+    const val SHADOW_OFFSET_Y_QUARTER = 10.0f
     const val SHADOW_BLUR_RADIUS = 12.0f
+    const val SHADOW_BLUR_RADIUS_HALF = 6.0f
 }
 
 // TODO these will eventually be defined differently to define degrees for a cast shadow
 fun getDefaultShadowOffset(): DpOffset = DpOffset(x = getShadowXOffset(), y= getShadowYOffset())
 
 fun getShadowXOffset(): Dp {
-    return SHADOW_OFFSET_X_FLOAT.dp
+    return SHADOW_OFFSET_X.dp
 }
 
 fun getShadowYOffset(): Dp {
-    return SHADOW_OFFSET_Y_FLOAT.dp
+    return SHADOW_OFFSET_Y.dp
 }
 
-fun getShadowBlurRadius(): Dp {
+fun getDefaultShadowBlurRadius(): Dp {
     return SHADOW_BLUR_RADIUS.dp
+}
+
+fun getShadowBlurRadius(imageSize: Dp): Dp {
+    return if (imageSize < 64.dp) {
+        SHADOW_BLUR_RADIUS_HALF.dp
+    } else {
+        SHADOW_BLUR_RADIUS.dp
+    }
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
@@ -1,6 +1,7 @@
 package com.daniellegolinsky.funshinetheme.designelements
 
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_FLOAT
@@ -13,6 +14,8 @@ object ThemeConstants {
 }
 
 // TODO these will eventually be defined differently to define degrees for a cast shadow
+fun getDefaultShadowOffset(): DpOffset = DpOffset(x = getShadowXOffset(), y= getShadowYOffset())
+
 fun getShadowXOffset(): Dp {
     return SHADOW_OFFSET_X_FLOAT.dp
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS_HALF
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS_QUARTER
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_HALF
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_QUARTER
@@ -21,7 +22,40 @@ object ThemeConstants {
     const val SHADOW_OFFSET_Y_QUARTER = 10.0f
     const val SHADOW_BLUR_RADIUS = 12.0f
     const val SHADOW_BLUR_RADIUS_HALF = 6.0f
+    const val SHADOW_BLUR_RADIUS_QUARTER = 3.0f
 }
+
+data class ShadowMatrix(
+    val shadowOffsetHeight: DpOffset,
+    val shadowBlur: Dp,
+)
+
+object Shadow {
+    fun getInformationShadow(itemSize: Dp): ShadowMatrix = ShadowMatrix(
+        shadowOffsetHeight = getDefaultShadowOffset(),
+        shadowBlur = getShadowBlurRadius(itemSize),
+    )
+    fun getDefaultInformationShadow(): ShadowMatrix = ShadowMatrix(
+        shadowOffsetHeight = getDefaultShadowOffset(),
+        shadowBlur = getDefaultShadowBlurRadius(),
+    )
+
+    fun getLowPriorityInformationShadow(): ShadowMatrix = ShadowMatrix(
+        shadowOffsetHeight = getHalfShadowOffset(),
+        shadowBlur = getShadowHalfBlurRadius(),
+    )
+
+    fun getControlHintShadow(): ShadowMatrix = ShadowMatrix(
+        shadowOffsetHeight = getQuarterShadowOffset(),
+        shadowBlur = getShadowQuarterBlurRadius(),
+    )
+
+    fun getControlShadow(): ShadowMatrix = ShadowMatrix(
+        shadowOffsetHeight = DpOffset(0.dp, 0.dp),
+        shadowBlur = 0.dp,
+    )
+}
+
 
 // TODO these will eventually be defined differently to define degrees for a cast shadow
 fun getDefaultShadowOffset(): DpOffset = DpOffset(x = getShadowXOffset(), y= getShadowYOffset())
@@ -64,4 +98,12 @@ fun getShadowBlurRadius(imageSize: Dp): Dp {
     } else {
         SHADOW_BLUR_RADIUS.dp
     }
+}
+
+fun getShadowHalfBlurRadius(): Dp {
+    return SHADOW_BLUR_RADIUS_HALF.dp
+}
+
+fun getShadowQuarterBlurRadius(): Dp {
+    return SHADOW_BLUR_RADIUS_QUARTER.dp
 }

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/designelements/ThemeConstants.kt
@@ -6,7 +6,11 @@ import androidx.compose.ui.unit.dp
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_BLUR_RADIUS_HALF
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_HALF
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_X_QUARTER
 import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_Y
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_Y_HALF
+import com.daniellegolinsky.funshinetheme.designelements.ThemeConstants.SHADOW_OFFSET_Y_QUARTER
 
 object ThemeConstants {
     const val SHADOW_OFFSET_X = 40.0f
@@ -22,12 +26,32 @@ object ThemeConstants {
 // TODO these will eventually be defined differently to define degrees for a cast shadow
 fun getDefaultShadowOffset(): DpOffset = DpOffset(x = getShadowXOffset(), y= getShadowYOffset())
 
+fun getHalfShadowOffset(): DpOffset = DpOffset(x = getHalfShadowXOffset(), y = getHalfShadowYOffset())
+
+fun getQuarterShadowOffset(): DpOffset = DpOffset(x = getQuarterShadowXOffset(), y = getQuarterShadowYOffset())
+
 fun getShadowXOffset(): Dp {
     return SHADOW_OFFSET_X.dp
 }
 
 fun getShadowYOffset(): Dp {
     return SHADOW_OFFSET_Y.dp
+}
+
+fun getHalfShadowXOffset(): Dp {
+    return SHADOW_OFFSET_X_HALF.dp
+}
+
+fun getHalfShadowYOffset(): Dp {
+    return SHADOW_OFFSET_Y_HALF.dp
+}
+
+fun getQuarterShadowXOffset(): Dp {
+    return SHADOW_OFFSET_X_QUARTER.dp
+}
+
+fun getQuarterShadowYOffset(): Dp {
+    return SHADOW_OFFSET_Y_QUARTER.dp
 }
 
 fun getDefaultShadowBlurRadius(): Dp {

--- a/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/font/FsTextStyle.kt
+++ b/funshinelibrary/src/main/java/com/daniellegolinsky/funshinetheme/font/FsTextStyle.kt
@@ -36,8 +36,8 @@ fun getBodyFontStyle(): TextStyle {
         shadow = Shadow(
             color = colorResource(id = R.color.black).copy(alpha = getShadowAlpha()),
             offset = Offset(
-                x = ThemeConstants.SHADOW_OFFSET_X_FLOAT,
-                y = ThemeConstants.SHADOW_OFFSET_Y_FLOAT
+                x = ThemeConstants.SHADOW_OFFSET_X,
+                y = ThemeConstants.SHADOW_OFFSET_Y,
             ),
             blurRadius = ThemeConstants.SHADOW_BLUR_RADIUS
         ),
@@ -60,8 +60,8 @@ fun getHeadingFontStyle(): TextStyle {
         shadow = Shadow(
             color = colorResource(id = R.color.black).copy(alpha = getShadowAlpha()),
             offset = Offset(
-                x = ThemeConstants.SHADOW_OFFSET_X_FLOAT,
-                y = ThemeConstants.SHADOW_OFFSET_Y_FLOAT
+                x = ThemeConstants.SHADOW_OFFSET_X,
+                y = ThemeConstants.SHADOW_OFFSET_Y,
             ),
             blurRadius = ThemeConstants.SHADOW_BLUR_RADIUS
         ),


### PR DESCRIPTION
Some changes to how shadow depth, icon size, and shadow blur are configured for FS Icons. The idea here is to tye blur to shadow "depth," the offset for the shadow. This is because, as an object gets closer to a surface, its shadow gets sharper, depending on its size in relation to the light source. 

By passing in a shadow matrix, and creating default sizes, I hope to make it easy to either customize this or use the defaults.

This also fixes padding issues with smaller offsets and smaller icon sizes, where even small icons would have massive padding and offsets that push both the icon and the shadows out of the view. 